### PR TITLE
detail setting up the API key initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ Install the dependencies
 npm i
 ```
 
-Set up a link to your development database. [Here](https://airtable.com/shrbYFEryJW3xEJYo) is the database, click the `copy base` button. Then, go to your copied base and look at its API documentation. If you go to the `help` button on the top right, and click on `API documentation`. Go to the `node.js` tab. You should see a line of code that looks like this:
+Set up a link to your development database. [Here](https://airtable.com/shrbYFEryJW3xEJYo) is the database, click the `copy base` button.
+
+If you haven't generated you API key already go to https://airtable.com/account and generate your Airtable API key now.
+
+Then, go to your copied base and look at its API documentation. If you go to the `help` button on the top right, and click on `API documentation`. Go to the `node.js` or `JavaScript` tab. You should see a line of code that looks like this:
 
 ```js
 const base = require("airtable").base("your_base_id")
 ```
 
-Copy the id from the `base` method.
+Click on `show API key` checkbox in the top right then copy the id from the `base` method.
 
 Create an `.env` file with two variables. Set the `GATSBY_AIRTABLE_BASE` to your base key.
 
@@ -50,7 +54,7 @@ GATSBY_AIRTABLE_API_KEY=your_api_key
 GATSBY_AIRTABLE_BASE=your_base_id
 ```
 
-If you turn on the `show API key` toggle, you'll also see your api key in a line of code that looks like this:
+After checking `show API key` toggle, you'll also see your api key in a line of code that looks like this:
 
 ```sh
 $ export AIRTABLE_API_KEY=your_api_key


### PR DESCRIPTION
If you haven't generated your API art the beginning then you do not have the option to check the `show API key`

It was a bit confusing initially, I've updated the README accordingly, thanks